### PR TITLE
Feature: highlight a selected page element in webview

### DIFF
--- a/src/component/app.tsx
+++ b/src/component/app.tsx
@@ -16,6 +16,7 @@ import { createMenu } from '../electron/menu';
 import * as MobX from 'mobx';
 import { observer } from 'mobx-react';
 import { Page } from '../store/page/page';
+// import { PageElement } from '../store/page/page_element';
 import { PageList } from './container/page_list';
 import * as PathUtils from 'path';
 import { PatternListContainer } from './container/pattern_list';
@@ -197,6 +198,17 @@ MobX.autorun(() => {
 	if (webviewTag && webviewTag.send) {
 		webviewTag.send('page-change', message);
 	}
+});
+
+MobX.autorun(() => {
+	const selectedElement = store.getSelectedElement();
+
+	const webviewTag: WebviewTag = document.getElementById('preview') as WebviewTag;
+	if (webviewTag && webviewTag.send) {
+		webviewTag.send('page-highlight', selectedElement.id);
+	}
+
+	console.log('selectedElement ->', selectedElement);
 });
 
 MobX.autorun(() => {

--- a/src/component/container/element_list.tsx
+++ b/src/component/container/element_list.tsx
@@ -133,6 +133,10 @@ export class ElementList extends React.Component<ElementListProps> {
 		value: PropertyValue,
 		selectedElement?: PageElement
 	): ListItemProps {
+		// if (value === this.props.store.selectedElement) {
+		// 	console.log('element list, selected -->', value, value === this.props.store.selectedElement)
+		// }
+
 		if (value instanceof Array) {
 			const items: ListItemProps[] = [];
 			(value as (string | number)[]).forEach((child, index: number) => {

--- a/src/component/presentation/preview.tsx
+++ b/src/component/presentation/preview.tsx
@@ -4,6 +4,7 @@ import { PageElement } from '../../store/page/page_element';
 import { Pattern } from '../../store/pattern/pattern';
 import { PropertyValue } from '../../store/page/property_value';
 import * as React from 'react';
+import { Store } from '../../store/store';
 import { TextPattern } from '../../store/pattern/text_pattern';
 
 class PatternWrapper extends React.Component<{}, PatternWrapperState> {
@@ -27,6 +28,7 @@ class PatternWrapper extends React.Component<{}, PatternWrapperState> {
 
 export interface PreviewProps {
 	page?: Page;
+	store: Store;
 }
 
 @observer
@@ -86,6 +88,12 @@ export class Preview extends React.Component<PreviewProps> {
 			componentProps.children = pageElement
 				.getChildren()
 				.map((child, index) => this.createComponent(child, String(index)));
+
+			// console.log(value.id, this.props.store.highlightedElement);
+			//
+			// if (value.id === this.props.store.highlightedElement) {
+			// 	console.log('FOUNDNNNDNDNDNNDNDNNDNND!', value);
+			// }
 
 			// Then, load the pattern factory
 			const patternPath: string = pattern.getAbsolutePath();

--- a/src/component/preview.tsx
+++ b/src/component/preview.tsx
@@ -32,7 +32,7 @@ class PreviewApp extends React.Component<PreviewAppProps, PreviewAppState> {
 
 		return (
 			<div>
-				<Preview page={this.props.store.getCurrentPage()} />
+				<Preview page={this.props.store.getCurrentPage()} store={this.props.store} />
 				{DevTools ? <DevTools /> : ''}
 			</div>
 		);
@@ -43,6 +43,12 @@ const store = new Store();
 
 ipcRenderer.on('page-change', (event: {}, message: JsonObject) => {
 	store.setPageFromJsonInternal(message.page as JsonObject, message.pageId as string);
+});
+
+ipcRenderer.on('page-highlight', (event: {}, id: number) => {
+	// store.setSelectedElement(message.selectedElement as PageElement);
+	console.log(id);
+	store.setHighlightedElement(id);
 });
 
 ipcRenderer.on('open-styleguide', (event: {}, message: JsonObject) => {

--- a/src/store/page/page_element.ts
+++ b/src/store/page/page_element.ts
@@ -33,6 +33,8 @@ export class PageElement {
 	 */
 	private patternPath: string;
 
+	private id: number;
+
 	/**
 	 * The pattern property values of this element's component instance.
 	 * Each key represents the property ID of the pattern, while the value holds the content
@@ -64,6 +66,8 @@ export class PageElement {
 		}
 
 		this.setParent(parent);
+
+		this.id = Math.random() + new Date().valueOf();
 	}
 
 	/**

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -74,6 +74,8 @@ export class Store {
 	 */
 	@MobX.observable private selectedElement?: PageElement;
 
+	@MobX.observable private highlightedElement?: number;
+
 	/**
 	 * The absolute and OS-dependent file-system path to the currently opened styleguide.
 	 * May be undefined if no styleguide is open.
@@ -516,5 +518,9 @@ export class Store {
 	 */
 	public setSelectedElement(selectedElement: PageElement | undefined): void {
 		this.selectedElement = selectedElement;
+	}
+
+	public setHighlightedElement(highlightedElement: number): void {
+		this.highlightedElement = highlightedElement;
 	}
 }


### PR DESCRIPTION
Work in progress.

- [ ] Somehow assign a serializable ID to every page element.
- [ ] Transfer the whole page per highlight to pass original IDs along with it. (and make it fast)
- [ ] Perhaps there's a reverse operation: click on an element in webview → select element in element list.